### PR TITLE
Do not allow use of tabs to indent code.

### DIFF
--- a/codewof/static/js/question_types/debugging.js
+++ b/codewof/static/js/question_types/debugging.js
@@ -25,7 +25,13 @@ $(document).ready(function () {
         styleActiveLine: true,
         autofocus: true,
         indentUnit: 4,
-        viewportMargin: Infinity
+        viewportMargin: Infinity,
+        // Replace tabs with 4 spaces. Taken from https://stackoverflow.com/questions/15183494/codemirror-tabs-to-spaces
+        extraKeys: {
+            "Tab": function(cm) {
+                cm.replaceSelection("    ", "end");
+            }
+        }
     });
 
     mark_lines_as_read_only(editor);
@@ -52,6 +58,9 @@ function run_code(editor, submit) {
         }
     }
     var user_code = editor.getValue();
+    console.log(user_code);
+    user_code = user_code.replace(/(.*?)\t/gm, "    ");
+    console.log(user_code);
     test_cases = base.run_test_cases(test_cases, user_code, run_python_code);
     if (submit) {
         base.ajax_request(

--- a/codewof/static/js/question_types/debugging.js
+++ b/codewof/static/js/question_types/debugging.js
@@ -58,9 +58,13 @@ function run_code(editor, submit) {
         }
     }
     var user_code = editor.getValue();
-    console.log(user_code);
-    user_code = user_code.replace(/(.*?)\t/gm, "    ");
-    console.log(user_code);
+    if (user_code.includes("\t")) {
+        // contains tabs
+        $("#indentation-warning").removeClass("d-none");
+        return; // do not run tests
+    } else {
+        $("#indentation-warning").addClass("d-none");
+    }
     test_cases = base.run_test_cases(test_cases, user_code, run_python_code);
     if (submit) {
         base.ajax_request(

--- a/codewof/static/js/question_types/function.js
+++ b/codewof/static/js/question_types/function.js
@@ -50,9 +50,13 @@ function run_code(editor, submit) {
         }
     }
     var user_code = editor.getValue();
-    console.log(user_code);
-    user_code = user_code.replace(/    /gm, "\t");
-    console.log(user_code);
+    if (user_code.includes("\t")) {
+        // contains tabs
+        $("#indentation-warning").removeClass("d-none");
+        return; // do not run tests
+    } else {
+        $("#indentation-warning").addClass("d-none");
+    }
     test_cases = base.run_test_cases(test_cases, user_code, run_python_code);
     if (submit) {
         base.ajax_request(

--- a/codewof/static/js/question_types/function.js
+++ b/codewof/static/js/question_types/function.js
@@ -20,7 +20,13 @@ $(document).ready(function () {
         styleActiveLine: true,
         autofocus: true,
         indentUnit: 4,
-        viewportMargin: Infinity
+        viewportMargin: Infinity,
+        // Replace tabs with 4 spaces. Taken from https://stackoverflow.com/questions/15183494/codemirror-tabs-to-spaces
+        extraKeys: {
+            "Tab": function(cm) {
+                cm.replaceSelection("    ", "end");
+            }
+        }
     });
 
     for (let i = 0; i < test_cases_list.length; i++) {
@@ -44,6 +50,9 @@ function run_code(editor, submit) {
         }
     }
     var user_code = editor.getValue();
+    console.log(user_code);
+    user_code = user_code.replace(/    /gm, "\t");
+    console.log(user_code);
     test_cases = base.run_test_cases(test_cases, user_code, run_python_code);
     if (submit) {
         base.ajax_request(

--- a/codewof/static/js/question_types/program.js
+++ b/codewof/static/js/question_types/program.js
@@ -51,7 +51,13 @@ function run_code(editor, submit) {
         }
     }
     var user_code = editor.getValue();
-    user_code = user_code.replace(/(.*?)\t/gm, "    ");
+    if (user_code.includes("\t")) {
+        // contains tabs
+        $("#indentation-warning").removeClass("d-none");
+        return; // do not run tests
+    } else {
+        $("#indentation-warning").addClass("d-none");
+    }
     test_cases = base.run_test_cases(test_cases, user_code, run_python_code);
     if (submit) {
         base.ajax_request(

--- a/codewof/static/js/question_types/program.js
+++ b/codewof/static/js/question_types/program.js
@@ -20,7 +20,13 @@ $(document).ready(function () {
         styleActiveLine: true,
         autofocus: true,
         indentUnit: 4,
-        viewportMargin: Infinity
+        viewportMargin: Infinity,
+        // Replace tabs with 4 spaces. Taken from https://stackoverflow.com/questions/15183494/codemirror-tabs-to-spaces
+        extraKeys: {
+            "Tab": function(cm) {
+                cm.replaceSelection("    ", "end");
+            }
+        }
     });
 
     for (let i = 0; i < test_cases_list.length; i++) {
@@ -45,6 +51,7 @@ function run_code(editor, submit) {
         }
     }
     var user_code = editor.getValue();
+    user_code = user_code.replace(/(.*?)\t/gm, "    ");
     test_cases = base.run_test_cases(test_cases, user_code, run_python_code);
     if (submit) {
         base.ajax_request(

--- a/codewof/templates/programming/question.html
+++ b/codewof/templates/programming/question.html
@@ -35,7 +35,7 @@
         {% endif %}
 
         <div id="indentation-warning" class="alert alert-danger d-none">
-            It looks like you have used tabs to indent your code. It is good Python style to use spaces, please remove any tab characters and try again.
+            It looks like you have used tab characters to indent your code. It is good Python style to use spaces, please remove any tab characters and try again.
         </div>
         <div class="d-flex justify-content-between mb-3">
             <button id="run_code" type="button" class="btn btn-primary">

--- a/codewof/templates/programming/question.html
+++ b/codewof/templates/programming/question.html
@@ -35,7 +35,7 @@
         {% endif %}
 
         <div id="indentation-warning" class="alert alert-danger d-none">
-            It looks like you have used tabs to indent your code. It is good Python style to use spaces, please remove the tab character and try again.
+            It looks like you have used tabs to indent your code. It is good Python style to use spaces, please remove any tab characters and try again.
         </div>
         <div class="d-flex justify-content-between mb-3">
             <button id="run_code" type="button" class="btn btn-primary">

--- a/codewof/templates/programming/question.html
+++ b/codewof/templates/programming/question.html
@@ -29,10 +29,13 @@
                 {% endif %}
             {% endif %}
             {% include "programming/question_components/editor-python.html" %}
+            <div class="mb-3">
+                <small class="text-muted font-italic mb-3">The tab button is configured to add 4 spaces.</small>
+            </div>
         {% endif %}
 
         <div id="indentation-warning" class="alert alert-danger d-none">
-            It looks like you have used tabs to indent your code. It is good Python style to use spaces.
+            It looks like you have used tabs to indent your code. It is good Python style to use spaces, please remove the tab character and try again.
         </div>
         <div class="d-flex justify-content-between mb-3">
             <button id="run_code" type="button" class="btn btn-primary">

--- a/codewof/templates/programming/question.html
+++ b/codewof/templates/programming/question.html
@@ -31,6 +31,9 @@
             {% include "programming/question_components/editor-python.html" %}
         {% endif %}
 
+        <div id="indentation-warning" class="alert alert-danger d-none">
+            It looks like you have used tabs to indent your code. It is good Python style to use spaces.
+        </div>
         <div class="d-flex justify-content-between mb-3">
             <button id="run_code" type="button" class="btn btn-primary">
                 Run code

--- a/codewof/templates/programming/question_components/editor-python.html
+++ b/codewof/templates/programming/question_components/editor-python.html
@@ -1,3 +1,3 @@
-<div class="border mb-3">
+<div class="border">
     <textarea id="code" class="hidden">{% if previous_attempt %}{{ previous_attempt.user_code }}{% elif question.QUESTION_TYPE == QUESTION_TYPE_DEBUGGING %}{{ question.initial_code }}{% endif %}</textarea>
 </div>


### PR DESCRIPTION
In #103 some code had failed tests because it contained a mixture of tabs and spaces in the indentation. This is expected Python behaviour, however the code passed when pasted into another Python IDE such as Wing. We are still unsure why this code passes in Wing.

To new programmers, finding a bug where a tab was used instead of spaces would be frustrating as it is practically invisible.

After some investigation and discussion with @eAlasdair we decided it would be best to enforce the use of spaces as this is good Python style.

In this PR, we have added code that will convert a tab key press to 4 spaces (along with a note below the IDE stating this, see below). The decision to not allow indentation using **just tabs** was influenced by the fact that if a user uses tabs in a debugging question, the code will not pass because on the locked lines spaces have been used.

In the case that code has been copied and pasted (i.e tabs will not be coverted to spaces because the tab key hasn't been pressed), we parse the users code and if tabs are detected we display the following warning:

![image](https://user-images.githubusercontent.com/16066822/67327422-63bf3e80-f574-11e9-999f-def21e23fb9d.png)


If tabs have been detected we do not run any tests.

Resolves #103 