### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.1
+- Update GCP health checks.
+
 ## 1.5.0
 - Add 7 new questions.
 - Fix test case where no argument was passed for the total of evens question. Fixes #101

--- a/codewof/config/__init__.py
+++ b/codewof/config/__init__.py
@@ -1,6 +1,6 @@
 """Configuration for Django system."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num

--- a/infrastructure/dev-deploy/app.yaml
+++ b/infrastructure/dev-deploy/app.yaml
@@ -24,10 +24,13 @@ resources:
   cpu: 1
   memory_gb: 3.75
 
-health_check:
-  enable_health_check: True
+liveness_check:
+  path: "/_ah/health"
   check_interval_sec: 5
-  timeout_sec: 4
+
+readiness_check:
+  path: "/_ah/health"
+  check_interval_sec: 5
 
 manual_scaling:
   instances: 1

--- a/infrastructure/prod-deploy/app.yaml
+++ b/infrastructure/prod-deploy/app.yaml
@@ -22,7 +22,10 @@ resources:
   cpu: 1
   memory_gb: 3.75
 
-health_check:
-  enable_health_check: True
+liveness_check:
+  path: "/_ah/health"
   check_interval_sec: 5
-  timeout_sec: 4
+
+readiness_check:
+  path: "/_ah/health"
+  check_interval_sec: 5


### PR DESCRIPTION
Both the develop and production deploys are failing to be deployed to Google App Engine. We need to update the GCP health checks. We will not know if this works until it is merged.

**Changelog**

- Update GCP health checks.