### PR TITLE
Update GCP health checks

### DIFF
--- a/infrastructure/dev-deploy/app.yaml
+++ b/infrastructure/dev-deploy/app.yaml
@@ -30,6 +30,7 @@ liveness_check:
 
 readiness_check:
   path: "/_ah/health"
+  check_interval_sec: 5
 
 manual_scaling:
   instances: 1

--- a/infrastructure/dev-deploy/app.yaml
+++ b/infrastructure/dev-deploy/app.yaml
@@ -24,10 +24,12 @@ resources:
   cpu: 1
   memory_gb: 3.75
 
-health_check:
-  enable_health_check: True
+liveness_check:
+  path: "/_ah/health"
   check_interval_sec: 5
-  timeout_sec: 4
+
+readiness_check:
+  path: "/_ah/health"
 
 manual_scaling:
   instances: 1

--- a/infrastructure/prod-deploy/app.yaml
+++ b/infrastructure/prod-deploy/app.yaml
@@ -28,3 +28,4 @@ liveness_check:
 
 readiness_check:
   path: "/_ah/health"
+  check_interval_sec: 5

--- a/infrastructure/prod-deploy/app.yaml
+++ b/infrastructure/prod-deploy/app.yaml
@@ -22,7 +22,9 @@ resources:
   cpu: 1
   memory_gb: 3.75
 
-health_check:
-  enable_health_check: True
+liveness_check:
+  path: "/_ah/health"
   check_interval_sec: 5
-  timeout_sec: 4
+
+readiness_check:
+  path: "/_ah/health"


### PR DESCRIPTION
Both the develop and production deploys are failing to be deployed to Google App Engine. We need to update the GCP health checks.

Since this is being merged into develop, we will not know if the changes to the prod deploy work until we do a release. But we will be able to see if the dev deploy changes work once this is merged.