### PR TITLE
Address issue and reduce number of queries in backdate command

### DIFF
--- a/codewof/programming/codewof_utils.py
+++ b/codewof/programming/codewof_utils.py
@@ -209,7 +209,7 @@ def check_badge_conditions(user):
 
 
 def calculate_badge_points(badges):
-    """Returns the number of points earned by the user for new badges, calculated by multiplying the badge tier by 10."""
+    """Return the number of points earned by the user for new badges."""
     points = 0
     for badge in badges:
         points += badge.badge_tier * POINTS_BADGE

--- a/codewof/programming/codewof_utils.py
+++ b/codewof/programming/codewof_utils.py
@@ -46,8 +46,6 @@ def add_points(question, profile, attempt):
     """
     num_attempts = Attempt.objects.filter(question=question, profile=profile)
     is_first_correct = len(Attempt.objects.filter(question=question, profile=profile, passed_tests=True)) == 1
-    logger.warning(num_attempts)
-    logger.warning(is_first_correct)
     points_to_add = 0
 
     # check if first passed

--- a/codewof/tests/programming/test_codewof_utils.py
+++ b/codewof/tests/programming/test_codewof_utils.py
@@ -72,28 +72,25 @@ class TestCodewofUtils(TestCase):
         self.assertEqual(points_after - points_before, POINTS_SOLUTION)
 
     def test_calculate_badge_points_tier_0(self):
-        user = User.objects.get(id=1)
         badge = Badge.objects.get(id_name="create-account")
         badges = [badge]
 
         points = calculate_badge_points(badges)
-        self.assertEqual(points, 0)
+        self.assertEqual(points, POINTS_BADGE * 0)
 
     def test_calculate_badge_points_tier_1(self):
-        user = User.objects.get(id=1)
         badge = Badge.objects.get(id_name="questions-solved-1")
         badges = [badge]
 
         points = calculate_badge_points(badges)
-        self.assertEqual(points, 10)
+        self.assertEqual(points, POINTS_BADGE * 1)
 
     def test_calculate_badge_points_tier_2(self):
-        user = User.objects.get(id=1)
         badge = Badge.objects.get(id_name="attempts-made-5")
         badges = [badge]
 
         points = calculate_badge_points(badges)
-        self.assertEqual(points, 20)
+        self.assertEqual(points, POINTS_BADGE * 2)
 
     def test_check_badge_conditions(self):
         generate_attempts()

--- a/codewof/tests/programming/test_codewof_utils.py
+++ b/codewof/tests/programming/test_codewof_utils.py
@@ -76,27 +76,24 @@ class TestCodewofUtils(TestCase):
         badge = Badge.objects.get(id_name="create-account")
         badges = [badge]
 
-        points_before = user.profile.points
-        calculate_badge_points(user, badges)
-        self.assertEqual(user.profile.points - points_before, badge.badge_tier * POINTS_BADGE)
+        points = calculate_badge_points(badges)
+        self.assertEqual(points, 0)
 
     def test_calculate_badge_points_tier_1(self):
         user = User.objects.get(id=1)
         badge = Badge.objects.get(id_name="questions-solved-1")
         badges = [badge]
 
-        points_before = user.profile.points
-        calculate_badge_points(user, badges)
-        self.assertEqual(user.profile.points - points_before, badge.badge_tier * POINTS_BADGE)
+        points = calculate_badge_points(badges)
+        self.assertEqual(points, 10)
 
     def test_calculate_badge_points_tier_2(self):
         user = User.objects.get(id=1)
         badge = Badge.objects.get(id_name="attempts-made-5")
         badges = [badge]
 
-        points_before = user.profile.points
-        calculate_badge_points(user, badges)
-        self.assertEqual(user.profile.points - points_before, badge.badge_tier * POINTS_BADGE)
+        points = calculate_badge_points(badges)
+        self.assertEqual(points, 20)
 
     def test_check_badge_conditions(self):
         generate_attempts()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 pytz==2019.3
 python-slugify==4.0.0
+python-dateutil==2.8.1
 Pillow==7.0.0
 argon2-cffi==19.2.0
 redis>=2.10.6, < 3  # pyup: < 3


### PR DESCRIPTION
- Approximately halves the number of database queries during a backdate through optimisation.
- Removes unnecessary logger logs
- Add `python-dateutil` to dependency list to resolve ModuleNotFoundError on GCP

We will have to merge this to develop and watch it's deployment to see whether or not these changes noticeably improve performance (#207) or resolve the module error on GCP