### PR TITLE
Update Django to 2.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is based off the Google App Engine Python runtime image
 # https://github.com/GoogleCloudPlatform/python-runtime
-FROM uccser/django:2.1.5
+FROM uccser/django:2.2.3
 
 # Add metadata to Docker image
 LABEL maintainer="csse-education-research@canterbury.ac.nz"

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,6 +1,6 @@
 # This Dockerfile is based off the Google App Engine Python runtime image
 # https://github.com/GoogleCloudPlatform/python-runtime
-FROM uccser/django:2.1.5-with-weasyprint
+FROM uccser/django:2.2.3-with-weasyprint
 
 # Add metadata to Docker image
 LABEL maintainer="csse-education-research@canterbury.ac.nz"

--- a/infrastructure/cloud-sql-proxy/Dockerfile
+++ b/infrastructure/cloud-sql-proxy/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is based off the Google App Engine Python runtime image
 # https://github.com/GoogleCloudPlatform/python-runtime
-FROM uccser/django:2.1.5
+FROM uccser/django:2.2.3
 
 # Add metadata to Docker image
 LABEL maintainer="csse-education-research@canterbury.ac.nz"


### PR DESCRIPTION
Note that the latest stable version is actually 2.2.12, but weasyprint does not work with this version. I have opted for version 2.2.3 which is what csfg and csu currently use.

Relates to #207 
