### PR TITLE
Add print statemements to check status of backdate command

### DIFF
--- a/codewof/programming/codewof_utils.py
+++ b/codewof/programming/codewof_utils.py
@@ -220,6 +220,8 @@ def backdate_points_and_badges():
     """Perform backdate of all points and badges for each profile in the system."""
     profiles = Profile.objects.all()
     num_profiles = len(profiles)
+    print("This is a TEMPORARY log to say we are about to start the for loop backdating users.\n"
+          + "The first statement in the for loop (starting now) is another print statement.")
     for i in range(num_profiles):
         print("Backdating users: " + str(i + 1) + "/" + str(num_profiles), end="\r")
         profile = profiles[i]

--- a/codewof/programming/management/commands/backdate_points_and_badges.py
+++ b/codewof/programming/management/commands/backdate_points_and_badges.py
@@ -11,4 +11,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Automatically called when the backdate command is given."""
+        print("Backdating points and badges\n")
         backdate_points_and_badges()


### PR DESCRIPTION
Backdate seems to be working (albeit slowly), yet isn't printing anything where it should be.
This PR adds further print statements to check two possible reasons:
A) Somehow because each (of the original) print statement is set to have no newline character, so it overwrites the previous one, none get printed at all
B) It's printing somewhere else for some whacky reason
relates to #207 