### PR TITLE
Reduce number of queries during a backdate to bare minimum

### DIFF
--- a/codewof/programming/codewof_utils.py
+++ b/codewof/programming/codewof_utils.py
@@ -37,7 +37,7 @@ POINTS_BONUS = 2
 
 def add_points(question, profile, attempt):
     """
-    Add appropriate number of points (if any) to user's profile after a question is answered.
+    Add appropriate number of points (if any) to user profile after a question is answered.
 
     Adds points to a user's profile for when the user answers a question correctly for the first time. If the user
     answers the question correctly the first time they answer, the user gains bonus points.
@@ -76,15 +76,15 @@ def save_goal_choice(request):
     return JsonResponse({})
 
 
-def get_days_consecutively_answered(user, user_attempts=None):
+def get_days_consecutively_answered(profile, user_attempts=None):
     """
     Get the number of consecutive days with questions attempted.
 
-    Gets all datetimes of attempts for the given user's profile, and checks for the longest continuous "streak" of
+    Gets all datetimes of attempts for the given user profile, and checks for the longest continuous "streak" of
     days where attempts were made. Returns an integer of the longest attempt "streak".
     """
     if user_attempts is None:
-        user_attempts = Attempt.objects.filter(profile=user.profile)
+        user_attempts = Attempt.objects.filter(profile=profile)
 
     # get datetimes from attempts in date form)
     attempts = user_attempts.datetimes('datetime', 'day', 'DESC')
@@ -115,10 +115,10 @@ def get_days_consecutively_answered(user, user_attempts=None):
     return highest_streak
 
 
-def get_questions_answered_in_past_month(user, user_attempts=None):
+def get_questions_answered_in_past_month(profile, user_attempts=None):
     """Get the number questions successfully answered in the past month."""
     if user_attempts is None:
-        user_attempts = Attempt.objects.filter(profile=user.profile)
+        user_attempts = Attempt.objects.filter(profile=profile)
 
     today = datetime.datetime.now().replace(tzinfo=None) + relativedelta(days=1)
     last_month = today - relativedelta(months=1)
@@ -126,9 +126,9 @@ def get_questions_answered_in_past_month(user, user_attempts=None):
     return len(solved)
 
 
-def check_badge_conditions(user, user_attempts=None):
+def check_badge_conditions(profile, user_attempts=None):
     """
-    Check if the user has earned new badges for their profile.
+    Check if the user profile has earned new badges for their profile.
 
     Checks if the user has received each available badge. If not, check if the user has earned these badges. Badges
     available to be checked for are profile creation, number of attempts made, number of questions answered, and
@@ -137,10 +137,10 @@ def check_badge_conditions(user, user_attempts=None):
     A badge will not be removed if the user had earned it before but now doesn't meet the conditions
     """
     if user_attempts is None:
-        user_attempts = Attempt.objects.filter(profile=user.profile)
+        user_attempts = Attempt.objects.filter(profile=profile)
 
     badge_objects = Badge.objects.all()
-    earned_badges = user.profile.earned_badges.all()
+    earned_badges = profile.earned_badges.all()
     new_badge_names = ""
     new_badge_objects = []
 
@@ -150,7 +150,7 @@ def check_badge_conditions(user, user_attempts=None):
         if creation_badge not in earned_badges:
             # create a new account creation
             Earned.objects.create(
-                profile=user.profile,
+                profile=profile,
                 badge=creation_badge
             )
             new_badge_names = new_badge_names + "- " + creation_badge.display_name + "\n"
@@ -168,7 +168,7 @@ def check_badge_conditions(user, user_attempts=None):
                 num_questions = int(question_badge.id_name.split("-")[2])
                 if len(solved) >= num_questions:
                     Earned.objects.create(
-                        profile=user.profile,
+                        profile=profile,
                         badge=question_badge
                     )
                     new_badge_names = new_badge_names + "- " + question_badge.display_name + "\n"
@@ -186,7 +186,7 @@ def check_badge_conditions(user, user_attempts=None):
                 num_questions = int(attempt_badge.id_name.split("-")[2])
                 if len(attempted) >= num_questions:
                     Earned.objects.create(
-                        profile=user.profile,
+                        profile=profile,
                         badge=attempt_badge
                     )
                     new_badge_names = new_badge_names + "- " + attempt_badge.display_name + "\n"
@@ -196,23 +196,23 @@ def check_badge_conditions(user, user_attempts=None):
         pass
 
     # consecutive days logged in badges
-    num_consec_days = get_days_consecutively_answered(user, user_attempts=user_attempts)
+    num_consec_days = get_days_consecutively_answered(profile, user_attempts=user_attempts)
     consec_badges = badge_objects.filter(id_name__contains="consecutive-days")
     for consec_badge in consec_badges:
         if consec_badge not in earned_badges:
             n_days = int(consec_badge.id_name.split("-")[2])
             if n_days <= num_consec_days:
                 Earned.objects.create(
-                    profile=user.profile,
+                    profile=profile,
                     badge=consec_badge
                 )
                 new_badge_names = new_badge_names + "- " + consec_badge.display_name + "\n"
                 new_badge_objects.append(consec_badge)
 
     new_points = calculate_badge_points(new_badge_objects)
-    user.profile.points += new_points
-    user.full_clean()
-    user.save()
+    profile.points += new_points
+    profile.full_clean()
+    profile.save()
     return new_badge_names
 
 
@@ -228,7 +228,7 @@ def backdate_points_and_badges():
     """Perform backdate of all points and badges for each profile in the system."""
     profiles = Profile.objects.all()
     num_profiles = len(profiles)
-    all_attempts = attempt.objects.all()
+    all_attempts = Attempt.objects.all()
     for i in range(num_profiles):
         # The commented out part below seems to break travis somehow
         print("Backdating user: " + str(i + 1) + "/" + str(num_profiles))  # , end="\r")
@@ -266,5 +266,5 @@ def backdate_points(profile, user_attempts=None):
 
 def backdate_badges(profile, user_attempts=None):
     """Re-check the profile for badges earned."""
-    check_badge_conditions(profile.user, user_attempts=user_attempts)
+    check_badge_conditions(profile, user_attempts=user_attempts)
     return profile

--- a/codewof/programming/codewof_utils.py
+++ b/codewof/programming/codewof_utils.py
@@ -228,13 +228,14 @@ def backdate_points_and_badges():
     """Perform backdate of all points and badges for each profile in the system."""
     profiles = Profile.objects.all()
     num_profiles = len(profiles)
+    all_attempts = attempt.objects.all()
     for i in range(num_profiles):
         # The commented out part below seems to break travis somehow
         print("Backdating user: " + str(i + 1) + "/" + str(num_profiles))  # , end="\r")
         profile = profiles[i]
-        attempts = Attempt.objects.filter(profile=profile)
+        attempts = all_attempts.filter(profile=profile)
         profile = backdate_badges(profile, user_attempts=attempts)
-        profile = backdate_points(profile)
+        profile = backdate_points(profile, user_attempts=attempts)
         # save profile when update is completed
         profile.full_clean()
         profile.save()

--- a/codewof/programming/codewof_utils.py
+++ b/codewof/programming/codewof_utils.py
@@ -250,7 +250,7 @@ def backdate_points(profile, user_attempts=None):
     questions = Question.objects.all()
     profile.points = 0
     for question in questions:
-        question_attempts = user_attempts.filter(profile=profile, question=question)
+        question_attempts = user_attempts.filter(question=question)
         has_passed = len(question_attempts.filter(passed_tests=True)) > 0
         first_passed = False
         if len(question_attempts) > 0:

--- a/codewof/programming/views.py
+++ b/codewof/programming/views.py
@@ -176,7 +176,7 @@ def save_question_attempt(request):
                 result['success'] = True
                 points_before = profile.points
                 points = add_points(question, profile, attempt)
-                badges = check_badge_conditions(profile.user)
+                badges = check_badge_conditions(profile)
                 points_after = profile.points
                 result['curr_points'] = points
                 result['point_diff'] = points_after - points_before
@@ -230,7 +230,7 @@ class CreateView(generic.base.TemplateView):
 #         user = self.request.user
 #         context['goal'] = user.profile.goal
 #         context['all_badges'] = Badge.objects.all()
-#         check_badge_conditions(user)
+#         check_badge_conditions(user.profile)
 #         # context['past_5_weeks'] = get_past_5_weeks(user)
 #         return context
 

--- a/codewof/tests/programming/test_codewof_utils.py
+++ b/codewof/tests/programming/test_codewof_utils.py
@@ -96,7 +96,7 @@ class TestCodewofUtils(TestCase):
         generate_attempts()
         user = User.objects.get(id=1)
         self.assertEqual(user.profile.earned_badges.count(), 0)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         earned_badges = user.profile.earned_badges
         self.assertTrue(earned_badges.filter(id_name='create-account').exists())
         self.assertTrue(earned_badges.filter(id_name='attempts-made-1').exists())
@@ -107,13 +107,13 @@ class TestCodewofUtils(TestCase):
     def test_get_days_consecutively_answered(self):
         generate_attempts()
         user = User.objects.get(id=1)
-        streak = get_days_consecutively_answered(user)
+        streak = get_days_consecutively_answered(user.profile)
         self.assertEqual(streak, 2)
 
     def test_get_questions_answered_in_past_month(self):
         generate_attempts()
         user = User.objects.get(id=1)
-        num_solved = get_questions_answered_in_past_month(user)
+        num_solved = get_questions_answered_in_past_month(user.profile)
         self.assertEqual(num_solved, 1)
 
     def test_backdate_points_correct_second_attempt(self):

--- a/codewof/tests/programming/test_models.py
+++ b/codewof/tests/programming/test_models.py
@@ -41,7 +41,7 @@ class ProfileModelTests(TestCase):
 
     def test_profile_starts_with_create_account_badge(self):
         user = User.objects.get(id=1)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="create-account")
         earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(earned), 1)
@@ -123,7 +123,7 @@ class BadgeModelTests(TestCase):
 
     def test_new_user_awards_create_account(self):
         user = User.objects.get(pk=1)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="create-account")
         earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(earned), 1)
@@ -132,7 +132,7 @@ class BadgeModelTests(TestCase):
     #     user = User.objects.get(pk=1)
     #     badge = Badge.objects.get(id_name="create-account")
     #     Earned.objects.create(profile=user.profile, badge=badge)
-    #     check_badge_conditions(user)
+    #     check_badge_conditions(user.profile)
 
     #     earned = Earned.objects.filter(profile=user.profile, badge=badge)
     #     self.assertEqual(len(earned), 1)
@@ -140,14 +140,14 @@ class BadgeModelTests(TestCase):
     # def test_adding_unknown_badge_doesnt_break(self):
     #     Badge.objects.create(id_name="notrealbadge", display_name="test", description="test")
     #     user = User.objects.get(pk=1)
-    #     check_badge_conditions(user)
+    #     check_badge_conditions(user.profile)
 
     def test_award_solve_1_on_correct_attempt(self):
         user = User.objects.get(pk=1)
         question = Question.objects.create(title="Test question", question_text="Print hello world")
         Attempt.objects.create(profile=user.profile, question=question, passed_tests=True, user_code='')
 
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="questions-solved-1")
         earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(earned), 1)
@@ -157,7 +157,7 @@ class BadgeModelTests(TestCase):
         question = Question.objects.create(title="Test question", question_text="Print hello world")
         Attempt.objects.create(profile=user.profile, question=question, passed_tests=False, user_code='')
 
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="questions-solved-1")
         earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(earned), 0)
@@ -168,7 +168,7 @@ class BadgeModelTests(TestCase):
 #         yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
 #         LoginDay.objects.select_for_update().filter(pk=2).update(day=yesterday.date())
 
-#         check_badge_conditions(user)
+#         check_badge_conditions(user.profile)
 #         badge = Badge.objects.get(id_name="login-3")
 #         earned = Earned.objects.filter(profile=user.profile, badge=badge)
 #         self.assertEquals(len(earned), 0)
@@ -183,7 +183,7 @@ class BadgeModelTests(TestCase):
 #         day_before_yesterday = datetime.datetime.now() - datetime.timedelta(days=2)
 #         LoginDay.objects.select_for_update().filter(pk=3).update(day=day_before_yesterday.date())
 
-#         check_badge_conditions(user)
+#         check_badge_conditions(user.profile)
 #         badge = Badge.objects.get(id_name="login-3")
 #         earned = Earned.objects.filter(profile=user.profile, badge=badge)
 #         self.assertEquals(len(earned), 1)
@@ -202,7 +202,7 @@ class BadgeModelTests(TestCase):
 #         last_week1 = datetime.datetime.now() - datetime.timedelta(days=3, weeks=1)
 #         LoginDay.objects.select_for_update().filter(pk=4).update(day=last_week1.date())
 
-#         check_badge_conditions(user)
+#         check_badge_conditions(user.profile)
 #         badge = Badge.objects.get(id_name="login-3")
 #         earned = Earned.objects.filter(profile=user.profile, badge=badge)
 #         self.assertEquals(len(earned), 1)
@@ -229,7 +229,7 @@ class BadgeModelTests(TestCase):
 #         last_week5 = datetime.datetime.now() - datetime.timedelta(days=5, weeks=1)
 #         LoginDay.objects.select_for_update().filter(pk=6).update(day=last_week5.date())
 
-#         check_badge_conditions(user)
+#         check_badge_conditions(user.profile)
 #         badge = Badge.objects.get(id_name="login-3")
 #         earned = Earned.objects.filter(profile=user.profile, badge=badge)
 #         self.assertEquals(len(earned), 1)
@@ -244,7 +244,7 @@ class BadgeModelTests(TestCase):
 #         last_week2 = datetime.datetime.now() - datetime.timedelta(days=2, weeks=1)
 #         LoginDay.objects.select_for_update().filter(pk=3).update(day=last_week2.date())
 
-#         check_badge_conditions(user)
+#         check_badge_conditions(user.profile)
 #         badge = Badge.objects.get(id_name="login-3")
 #         earned = Earned.objects.filter(profile=user.profile, badge=badge)
 #         self.assertEquals(len(earned), 0)
@@ -261,35 +261,35 @@ class EarnedModelTests(TestCase):
 
     def test_questions_solved_1_earnt(self):
         user = User.objects.get(id=1)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="questions-solved-1")
         qs1_earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(qs1_earned), 1)
 
     def test_create_account_earnt(self):
         user = User.objects.get(id=1)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="create-account")
         create_acc_earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(create_acc_earned), 1)
 
     def test_attempts_made_5_earnt(self):
         user = User.objects.get(id=1)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="attempts-made-5")
         attempts_5_earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(attempts_5_earned), 1)
 
     def test_attempts_made_1_earnt(self):
         user = User.objects.get(id=1)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="attempts-made-1")
         attempts1_earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(attempts1_earned), 1)
 
     def test_consecutive_days_2_earnt(self):
         user = User.objects.get(id=1)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         badge = Badge.objects.get(id_name="consecutive-days-2")
         consec_days_earned = Earned.objects.filter(profile=user.profile, badge=badge)
         self.assertEqual(len(consec_days_earned), 1)

--- a/codewof/users/views.py
+++ b/codewof/users/views.py
@@ -134,10 +134,10 @@ class UserDetailView(LoginRequiredMixin, DetailView):
         context['codewof_profile'] = self.object.profile
         context['goal'] = user.profile.goal
         context['all_badges'] = Badge.objects.all()
-        questions_answered = get_questions_answered_in_past_month(user)
+        questions_answered = get_questions_answered_in_past_month(user.profile)
         context['num_questions_answered'] = questions_answered
         logger.warning(questions_answered)
-        check_badge_conditions(user)
+        check_badge_conditions(user.profile)
         return context
 
 


### PR DESCRIPTION
Adds optional `user_attempts` parameter to several `codewof_utils` functions and replaces the user object parameter with the more relevant Profile object in several places
Now there should only be one of each necessary query to backdate all users