### PR TITLE
Reimplement backdate command into sampledata command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
           skip_cleanup: true
           on:
             branch: master
-    - stage: database backdate  #TEMPORARY
+    - stage: database backdate
       script: skip
       name: "Backdate development database"
       deploy:
@@ -75,7 +75,7 @@ jobs:
           script: bash ./infrastructure/dev-deploy/backdate.sh
           skip_cleanup: true
           on:
-            branch: develop  #TEMPORARY END
+            branch: develop
 notifications:
   email: false
   slack:

--- a/codewof/general/management/commands/sampledata.py
+++ b/codewof/general/management/commands/sampledata.py
@@ -21,6 +21,7 @@ class Command(management.base.BaseCommand):
     help = "Add sample data to database."
 
     def add_arguments(self, parser):
+        """Interprets arguments passed to command."""
         parser.add_argument(
             '--skip_backdate',
             action='store_true',

--- a/codewof/general/management/commands/sampledata.py
+++ b/codewof/general/management/commands/sampledata.py
@@ -20,12 +20,21 @@ class Command(management.base.BaseCommand):
 
     help = "Add sample data to database."
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--skip_backdate',
+            action='store_true',
+            help='skip backdate step',
+            )
+
     def handle(self, *args, **options):
         """Automatically called when the sampledata command is given."""
         if settings.DEPLOYMENT_TYPE == 'prod' and not settings.DEBUG:
             raise management.base.CommandError(
                 'This command can only be executed in DEBUG mode on non-production website.'
             )
+
+        skip = options['skip_backdate']
 
         # Clear all data
         print(LOG_HEADER.format('Wipe database'))
@@ -88,4 +97,7 @@ class Command(management.base.BaseCommand):
         print('Attempts loaded.\n')
 
         # Award points and badges
-        # management.call_command('backdate_points_and_badges') TEMPORARY
+        if not skip:
+            management.call_command('backdate_points_and_badges')
+        else:
+            print('Ignoring backdate step as requested.\n')

--- a/codewof/programming/codewof_utils.py
+++ b/codewof/programming/codewof_utils.py
@@ -3,21 +3,15 @@
 import datetime
 import json
 import logging
-import time
-import statistics
 from dateutil.relativedelta import relativedelta
 
 from programming.models import (
     Profile,
-    # Question,
     Attempt,
     Badge,
     Earned,
 )
 from django.http import JsonResponse
-# from django.conf import settings
-
-# time_zone = settings.TIME_ZONE
 
 logger = logging.getLogger(__name__)
 del logging
@@ -231,9 +225,6 @@ def calculate_badge_points(badges):
 
 def backdate_points_and_badges():
     """Perform backdate of all points and badges for each profile in the system."""
-    backdate_badges_times = []
-    backdate_points_times = []
-    time_before = time.perf_counter()
     profiles = Profile.objects.all()
     num_profiles = len(profiles)
     all_attempts = Attempt.objects.all()
@@ -242,31 +233,12 @@ def backdate_points_and_badges():
         print("Backdating user: " + str(i + 1) + "/" + str(num_profiles))  # , end="\r")
         profile = profiles[i]
         attempts = all_attempts.filter(profile=profile)
-
-        badges_time_before = time.perf_counter()
         profile = backdate_badges(profile, user_attempts=attempts)
-        badges_time_after = time.perf_counter()
-        backdate_badges_times.append(badges_time_after - badges_time_before)
-
-        points_time_before = time.perf_counter()
         profile = backdate_points(profile, user_attempts=attempts)
-        points_time_after = time.perf_counter()
-        backdate_points_times.append(points_time_after - points_time_before)
         # save profile when update is completed
         profile.full_clean()
         profile.save()
-    time_after = time.perf_counter()
     print("\nBackdate complete.")
-
-    badges_ave = statistics.mean(backdate_badges_times)
-    print(f"Average time per user to backdate badges: {badges_ave:0.4f} seconds")
-
-    points_ave = statistics.mean(backdate_points_times)
-    print(f"Average time per user to backdate points: {points_ave:0.4f} seconds")
-
-    duration = time_after - time_before
-    average = duration / num_profiles
-    print(f"Backdate duration {duration:0.4f} seconds, average per user {average:0.4f} seconds")
 
 
 def backdate_points(profile, user_attempts=None):

--- a/codewof/programming/codewof_utils.py
+++ b/codewof/programming/codewof_utils.py
@@ -3,6 +3,8 @@
 import datetime
 import json
 import logging
+import time
+import statistics
 from dateutil.relativedelta import relativedelta
 
 from programming.models import (
@@ -36,7 +38,6 @@ def add_points(question, profile, attempt):
 
     Adds points to a user's profile for when the user answers a question correctly for the first time. If the user
     answers the question correctly the first time they answer, the user gains bonus points.
-
     Subsequent correct answers should not award any points.
     """
     attempts = Attempt.objects.filter(question=question, profile=profile)
@@ -225,6 +226,9 @@ def calculate_badge_points(badges):
 
 def backdate_points_and_badges():
     """Perform backdate of all points and badges for each profile in the system."""
+    backdate_badges_times = []
+    backdate_points_times = []
+    time_before = time.perf_counter()
     profiles = Profile.objects.all()
     num_profiles = len(profiles)
     all_attempts = Attempt.objects.all()
@@ -233,12 +237,31 @@ def backdate_points_and_badges():
         print("Backdating user: " + str(i + 1) + "/" + str(num_profiles))  # , end="\r")
         profile = profiles[i]
         attempts = all_attempts.filter(profile=profile)
+
+        badges_time_before = time.perf_counter()
         profile = backdate_badges(profile, user_attempts=attempts)
+        badges_time_after = time.perf_counter()
+        backdate_badges_times.append(badges_time_after - badges_time_before)
+
+        points_time_before = time.perf_counter()
         profile = backdate_points(profile, user_attempts=attempts)
+        points_time_after = time.perf_counter()
+        backdate_points_times.append(points_time_after - points_time_before)
         # save profile when update is completed
         profile.full_clean()
         profile.save()
+    time_after = time.perf_counter()
     print("\nBackdate complete.")
+
+    badges_ave = statistics.mean(backdate_badges_times)
+    logger.debug(f"Average time per user to backdate badges: {badges_ave:0.4f} seconds")
+
+    points_ave = statistics.mean(backdate_points_times)
+    logger.debug(f"Average time per user to backdate points: {points_ave:0.4f} seconds")
+
+    duration = time_after - time_before
+    average = duration / num_profiles
+    logger.debug(f"Backdate duration {duration:0.4f} seconds, average per user {average:0.4f} seconds")
 
 
 def backdate_points(profile, user_attempts=None):

--- a/dev
+++ b/dev
@@ -182,7 +182,7 @@ cmd_createsuperuser() {
 defhelp createsuperuser "Create superuser in Django system."
 
 cmd_sampledata() {
-  docker-compose exec django /docker_venv/bin/python3 ./manage.py sampledata
+  docker-compose exec django /docker_venv/bin/python3 ./manage.py sampledata $1
 }
 defhelp sampledata "Add sample data to website."
 

--- a/infrastructure/dev-deploy/update-content.sh
+++ b/infrastructure/dev-deploy/update-content.sh
@@ -14,4 +14,4 @@ source ./codewof/load-dev-envs.sh
 # Update the database and website sample content
 ./dev start
 ./dev migrate
-./dev sampledata
+./dev sampledata --skip_backdate


### PR DESCRIPTION
Sampledata command now runs backdate when it finishes, unless the argument `--skip_backdate` is passed. Also the logs showing statistics have been moved to logger debug logs

I haven't checked whether logger correctly logs the debug statements, as I don't know how to check