### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - stage: test
       script: ./dev ci test_suite
       name: "Run test suite"
-      script: ./dev ci style
+    - script: ./dev ci style
       name: "Run style checker"
     - stage: development deployment
       script: skip


### PR DESCRIPTION
The hyphen is used as a separator between scripts, that's why only one test script is run