### PR TITLE
Improve gamification toasts

### DIFF
--- a/codewof/static/js/question_types/base.js
+++ b/codewof/static/js/question_types/base.js
@@ -34,11 +34,11 @@ function update_gamification(data) {
     $("#user_points_navbar").load(location.href + " #user_points_navbar"); // Add space between URL and selector.
 
     point_diff = parseInt(data.point_diff);
-    if(point_diff > 0) {
+    if (point_diff > 0) {
         $("#point_toast_header").text("Points earned!");
         $("#point_toast_body").text("You earned " + point_diff.toString() +" points!");
         $(document).ready(function(){
-            $("#point_toast").toast('show', {delay: 5000});
+            $("#point_toast").toast('show', {delay: 8000});
         });
     }
 
@@ -47,7 +47,7 @@ function update_gamification(data) {
         $("#achievement_toast_header").text("New achievements!");
         $("#achievement_toast_body").text(achievements);
         $(document).ready(function(){
-            $("#achievement_toast").toast('show', {delay: 5000});
+            $("#achievement_toast").toast('show', {delay: 8000});
         });
     }
 

--- a/codewof/templates/programming/question.html
+++ b/codewof/templates/programming/question.html
@@ -62,7 +62,7 @@
         <a class="btn btn-outline-primary" href="{% url 'users:dashboard' %}">Return to dashboard</a>
     </div>
     <div id="toast-container">
-      <div id="achievement_toast" data-animation="true" class="toast" role="alert" data-delay=3000 aria-live="assertive" aria-atomic="true">
+      <div id="achievement_toast" data-animation="true" class="toast hide" role="alert" data-delay=8000 aria-live="assertive" aria-atomic="true">
         <div class="toast-header" id="achievement_toast_header">
           <strong>You earned a new achievement!</strong>
           <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
@@ -73,7 +73,7 @@
           Check your dashboard for details!
         </div>
       </div>
-      <div id="point_toast" data-animation="true" class="toast" role="alert" data-delay=3000 aria-live="assertive" aria-atomic="true">
+      <div id="point_toast" data-animation="true" class="toast hide" role="alert" data-delay=8000 aria-live="assertive" aria-atomic="true">
         <div class="toast-header" id="point_toast_header">
           <img src="{% static 'svg/icons8-points.svg' %}"/>
           <strong>You earned points!</strong>


### PR DESCRIPTION
**Changes**

- Hide the toast on page load so that the div does not take up any space.
- Show toasts for 8 seconds instead of 5.

Resolves #256 