### PR TITLE
Update pillow to 7.2.0.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 pytz==2019.3
 python-slugify==4.0.0
 python-dateutil==2.8.1
-Pillow==7.0.0
+Pillow==7.2.0
 argon2-cffi==19.2.0
 redis>=2.10.6, < 3  # pyup: < 3
 filetype==1.0.4


### PR DESCRIPTION
Pillow 7.0.0 has known security vulnerabilities.