### PR TITLE
Fix bug in page helpers where elements weren't scrolled to properly

### DIFF
--- a/codewof/static/js/question_types/base.js
+++ b/codewof/static/js/question_types/base.js
@@ -133,13 +133,15 @@ function scroll_to_element(containerId, element) {
     // For use by the tutorials
     var container = $('#' + containerId);
     var contWidth = container.width();
-    var elemLeft = $(element).offset().left - container.offset().left;
+    var contLeft = container.offset().left;
+    var elemLeft = $(element).offset().left - contLeft; // wrt container
     var elemWidth = element.width();
-    var isInView = (elemLeft >= 0 && ((elemLeft + elemWidth) <= contWidth));
+    var isInView = elemLeft >= 0 && (elemLeft + elemWidth) <= contWidth;
 
     if (!isInView) {
-        var scrollLeftValue = element.offset().left;
-        container.scrollLeft(scrollLeftValue);
+        container.scrollLeft(0);
+        var scrollTo = $(element).offset().left - contLeft;
+        container.scrollLeft(scrollTo);
     }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25916475/92339125-a516f900-f108-11ea-9db0-efbe3902d9c4.png)

Fixes the calculation that scrolls the test box when the tutorial covers a specific part of it