### PR TITLE
Revert "Bump python-markdown-math from 0.6 to 0.8"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ psycopg2==2.9.5
 
 # Content loading
 verto==1.1.1
-python-markdown-math==0.8
+python-markdown-math==0.6
 PyYAML==5.4.1
 
 # Style checker


### PR DESCRIPTION
Reverts uccser/codewof#640